### PR TITLE
fixed stz'ing BGSCROLLX twice

### DIFF
--- a/src/main.s
+++ b/src/main.s
@@ -173,7 +173,7 @@ padwait:
   bit VBLSTATUS
   bne padwait
   stz BGSCROLLX
-  stz BGSCROLLX
+  stz BGSCROLLY
 
   jmp forever
 .endproc


### PR DESCRIPTION
fix for https://github.com/pinobatch/lorom-template/issues/4